### PR TITLE
Upgrade to null safety, bump version to 0.6.0

### DIFF
--- a/example/demo/pubspec.yaml
+++ b/example/demo/pubspec.yaml
@@ -2,13 +2,13 @@ name: mdc_web_example_demo
 description: Example usage of the mdc_web package.
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
  mdc_web:
    path: ../..
 
 dev_dependencies:
+  build_runner: ^1.11.0
+  build_web_compilers: ^2.16.0
   sass_builder: ^2.1.0
-  build_runner: ^1.6.0
-  build_web_compilers: ^2.2.0

--- a/example/demo/web/main.dart
+++ b/example/demo/web/main.dart
@@ -7,8 +7,8 @@ import 'package:mdc_web/mdc_web.dart';
 import 'main_demos.dart';
 import 'package:js/js.dart';
 
-Element _content;
-Element get content => _content;
+Element? _content;
+Element? get content => _content;
 
 // @JS('mdc.autoInit')
 // external void autoInit([Node root, void Function(String) warn]);
@@ -34,7 +34,7 @@ void main() async {
   addDyslexicOption();
   handleSelectedText();
 
-  _content = querySelector('#content');
+  _content = querySelector('#content')!;
 
   topAppBar();
   // chips();
@@ -48,7 +48,7 @@ void main() async {
   print(await fetchGoodBoys().toList());
 
   define('a-b', allowInterop(() => Test));
-  document.body.append(Element.tag('a-b'));
+  document.body!.append(Element.tag('a-b'));
 }
 
 class Test extends HtmlElement {
@@ -65,7 +65,7 @@ Element addSection(String id, String title, String demoUrl) {
   setInnerHtml(section, '''
 
     ''');
-  content.append(section);
+  content!.append(section);
   return section;
 }
 
@@ -73,7 +73,8 @@ void setInnerHtml(Element el, String html) =>
     el.setInnerHtml(html, treeSanitizer: NodeTreeSanitizer.trusted);
 
 /// Listen to events and print the event name and event details when they happen.
-void listen<T>(T target, final String eventName, [void Function(T) callback]) {
+/// void listen<T>(T target, final String eventName, [void Function(T) callback]) {
+void listen<T>(T target, final String eventName, [void Function(T)? callback]) {
   final handler = (Event event) {
     print('Event "$eventName": ${stringify(event)}');
     if (callback != null) callback(target);
@@ -86,8 +87,10 @@ void listen<T>(T target, final String eventName, [void Function(T) callback]) {
 /// I must be bored.
 void addDyslexicOption() {
   final dyslexic = MDCSwitch(querySelector('.mdc-switch'));
+  final checked = dyslexic.checked;
+  if (checked == null) return;
   dyslexic.listen('change', (e) {
-    document.body.className = dyslexic.checked ? 'dyslexic' : '';
+    document.body!.className = checked ? 'dyslexic' : '';
   });
 }
 
@@ -95,7 +98,9 @@ void addDyslexicOption() {
 void handleSelectedText() {
   document.addEventListener('mouseup', (event) {
     final sel = window.getSelection();
-    if (sel.toString().length > 0 && sel.rangeCount > 0) {
+    if (sel == null) return;
+    final rangeCount = sel.rangeCount;
+    if (sel.toString().length > 0 && rangeCount != null && rangeCount > 0) {
       final range = sel.getRangeAt(0).cloneRange();
       try {
         range.surroundContents(SpanElement()..className = 'selected-text');
@@ -108,7 +113,7 @@ void handleSelectedText() {
   document.addEventListener('mousedown', (event) {
     if (window.getSelection().toString().length == 0) {
       querySelectorAll('.selected-text').forEach((el) {
-        el.replaceWith(Text(el.text));
+        el.replaceWith(Text(el.text ?? ''));
       });
     }
   });

--- a/example/demo/web/main_demos.dart
+++ b/example/demo/web/main_demos.dart
@@ -195,7 +195,7 @@ void topAppBar() {
 // }
 
 void snackbar() {
-  final snackbar = MDCSnackbar(querySelector('.mdc-snackbar'))
+  final snackbar = MDCSnackbar(querySelector('.mdc-snackbar')!)
     ..labelText = 'hi'
     ..actionButtonText = 'click'
     ..listen('MDCSnackbar:closing', (e) {

--- a/example/simple/pubspec.yaml
+++ b/example/simple/pubspec.yaml
@@ -2,13 +2,14 @@ name: mdc_web_example_simple
 description: Example usage of the mdc_web package.
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
  mdc_web:
    path: ../..
 
 dev_dependencies:
-  build_runner: ^0.10.0
-  build_web_compilers: ^0.4.0
-  sass_builder: any
+  build_runner: ^1.11.0
+  build_web_compilers: ^2.16.0
+  sass_builder: ^2.1.0
+

--- a/example/themes/pubspec.yaml
+++ b/example/themes/pubspec.yaml
@@ -2,15 +2,16 @@ name: mdc_web_example_themes
 description: Example usage of the mdc_web package.
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
  mdc_web:
    path: ../..
 
 dev_dependencies:
-  build_runner: ^0.10.0
-  build_web_compilers: ^0.4.0
-  js: any
-  sass_builder: any
+  build_runner: ^1.11.0
+  build_web_compilers: ^2.16.0
+  js: ^0.6.3
+  sass_builder: ^2.1.0
+
 

--- a/example/themes/web/main.dart
+++ b/example/themes/web/main.dart
@@ -31,12 +31,12 @@ void main() {
   themeSwitch.checked = window.localStorage['theme'] == 'Dark';
   themeSwitch.listen('change', (e) {
     window.localStorage['theme'] = themeSwitch.checked ? 'Dark' : 'Light';
-    final LinkElement? styles = querySelector('#theme') as LinkElement?;
-    window.animationFrame.then((time) => styles!.href =
+    final LinkElement styles = querySelector('#theme') as LinkElement;
+    window.animationFrame.then((time) => styles.href =
         themeSwitch.checked ? 'theme-dark.css' : 'theme-light.css');
   });
 
-  final menuButton = querySelector('#overflow-menu-button')!;
+  final menuButton = querySelector('#overflow-menu-button');
   final menu = MDCMenu(querySelector('#overflow-menu'));
   menu.setAnchorMargin(AnchorMargin(top: topAppBar.root.clientHeight / 2));
   menuButton.addEventListener('click', (event) {

--- a/example/themes/web/main.dart
+++ b/example/themes/web/main.dart
@@ -31,12 +31,12 @@ void main() {
   themeSwitch.checked = window.localStorage['theme'] == 'Dark';
   themeSwitch.listen('change', (e) {
     window.localStorage['theme'] = themeSwitch.checked ? 'Dark' : 'Light';
-    final LinkElement styles = querySelector('#theme');
-    window.animationFrame.then((time) => styles.href =
+    final LinkElement? styles = querySelector('#theme') as LinkElement?;
+    window.animationFrame.then((time) => styles!.href =
         themeSwitch.checked ? 'theme-dark.css' : 'theme-light.css');
   });
 
-  final menuButton = querySelector('#overflow-menu-button');
+  final menuButton = querySelector('#overflow-menu-button')!;
   final menu = MDCMenu(querySelector('#overflow-menu'));
   menu.setAnchorMargin(AnchorMargin(top: topAppBar.root.clientHeight / 2));
   menuButton.addEventListener('click', (event) {

--- a/example/themes/web/main.dart
+++ b/example/themes/web/main.dart
@@ -30,17 +30,19 @@ void main() {
   final themeSwitch = MDCSwitch(querySelector('#theme-switch'));
   themeSwitch.checked = window.localStorage['theme'] == 'Dark';
   themeSwitch.listen('change', (e) {
-    window.localStorage['theme'] = themeSwitch.checked ? 'Dark' : 'Light';
-    final LinkElement styles = querySelector('#theme') as LinkElement;
-    window.animationFrame.then((time) => styles.href =
-        themeSwitch.checked ? 'theme-dark.css' : 'theme-light.css');
+    final checked = themeSwitch.checked;
+    if (checked == null) return;
+    window.localStorage['theme'] = checked ? 'Dark' : 'Light';
+    final LinkElement? styles = querySelector('#theme') as LinkElement?;
+    window.animationFrame.then((time) =>
+        styles!.href = checked ? 'theme-dark.css' : 'theme-light.css');
   });
 
-  final menuButton = querySelector('#overflow-menu-button');
+  final menuButton = querySelector('#overflow-menu-button')!;
   final menu = MDCMenu(querySelector('#overflow-menu'));
   menu.setAnchorMargin(AnchorMargin(top: topAppBar.root.clientHeight / 2));
   menuButton.addEventListener('click', (event) {
-    menu.open = !menu.open;
+    menu.open = !menu.open!;
   });
 
   /// Automatically creates MDC-Web components from html elements that have a

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -1,4 +1,4 @@
-import 'dart:html' show Element, EventListener;
+import 'dart:html' show Element, EventListener, Event;
 import 'package:js/js.dart' show allowInterop, allowInteropCaptureThis;
 import 'package:meta/meta.dart';
 import 'mdc_web/base.dart';

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -26,14 +26,14 @@ abstract class MDCComponent {
       js.listen(
           type,
           captureThis
-              ? allowInteropCaptureThis(handler)
+              ? allowInteropCaptureThis(handler) as dynamic Function(Event)
               : allowInterop(handler));
   void unlisten(String type, EventListener handler,
           {bool captureThis: false}) =>
       js.unlisten(
           type,
           captureThis
-              ? allowInteropCaptureThis(handler)
+              ? allowInteropCaptureThis(handler) as dynamic Function(Event)
               : allowInterop(handler));
   void emit(String type, data, [bool shouldBubble = false]) =>
       js.emit(type, data, shouldBubble);

--- a/lib/src/checkbox.dart
+++ b/lib/src/checkbox.dart
@@ -13,7 +13,7 @@ import 'mdc_web/checkbox.dart';
 class MDCCheckbox extends MDCComponent implements MDCSelectionControl {
   static MDCCheckbox attachTo(Element root) => MDCCheckbox._attach(root);
   MDCCheckbox._attach(Element root) : _js = CheckboxComponent.attachTo(root);
-  MDCCheckbox(Element root, [MDCFoundation foundation, args])
+  MDCCheckbox(Element? root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   @override
@@ -33,7 +33,7 @@ class MDCCheckbox extends MDCComponent implements MDCSelectionControl {
 }
 
 CheckboxComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element? root, MDCFoundation? foundation, args) =>
     foundation == null
         ? CheckboxComponent(root)
         : args == null

--- a/lib/src/checkbox.dart
+++ b/lib/src/checkbox.dart
@@ -20,16 +20,16 @@ class MDCCheckbox extends MDCComponent implements MDCSelectionControl {
   CheckboxComponent get js => _js;
   final CheckboxComponent _js;
 
-  bool get checked => js.checked;
-  set checked(bool value) => js.checked = value;
-  bool get indeterminate => js.indeterminate;
-  set indeterminate(bool value) => js.indeterminate = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
-  String get value => js.value;
-  set value(String value) => js.value = value;
+  bool? get checked => js.checked;
+  set checked(bool? value) => js.checked = value;
+  bool? get indeterminate => js.indeterminate;
+  set indeterminate(bool? value) => js.indeterminate = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
+  String? get value => js.value;
+  set value(String? value) => js.value = value;
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 CheckboxComponent _preserveUndefined(

--- a/lib/src/chips.dart
+++ b/lib/src/chips.dart
@@ -63,11 +63,11 @@ class MDCChip extends MDCComponent {
   /// This will be the same as the id attribute on the root element. If an id is
   /// not provided, a unique one will be generated.
   String get id => js.id;
-  bool get selected => js.selected;
-  set selected(bool value) => js.selected = value;
-  bool get shouldRemoveOnTrailingIconClick =>
+  bool? get selected => js.selected;
+  set selected(bool? value) => js.selected = value;
+  bool? get shouldRemoveOnTrailingIconClick =>
       js.shouldRemoveOnTrailingIconClick;
-  set shouldRemoveOnTrailingIconClick(bool value) =>
+  set shouldRemoveOnTrailingIconClick(bool? value) =>
       js.shouldRemoveOnTrailingIconClick = value;
   MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
 

--- a/lib/src/chips.dart
+++ b/lib/src/chips.dart
@@ -14,7 +14,7 @@ class MDCChipSet extends MDCComponent {
   static MDCChipSet attachTo(Element root) => MDCChipSet._attach(root);
   MDCChipSet._attach(Element root) : _js = ChipSetComponent.attachTo(root);
 
-  MDCChipSet(Element root, [MDCFoundation foundation, args])
+  MDCChipSet(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefinedChipSet(root, foundation, args);
 
   @override
@@ -54,7 +54,7 @@ class MDCChip extends MDCComponent {
   MDCChip._attach(Element root) : _js = ChipComponent.attachTo(root);
   MDCChip._(this._js);
 
-  MDCChip(Element root, [MDCFoundation foundation, args])
+  MDCChip(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefinedChip(root, foundation, args);
 
   ChipComponent get js => _js;

--- a/lib/src/dialog.dart
+++ b/lib/src/dialog.dart
@@ -21,12 +21,12 @@ class MDCDialog extends MDCComponent {
   final DialogComponent _js;
 
   bool get isOpen => js.isOpen;
-  String get escapeKeyAction => js.escapeKeyAction;
-  set escapeKeyAction(String value) => js.escapeKeyAction = value;
-  String get scrimClickAction => js.scrimClickAction;
-  set scrimClickAction(String value) => js.scrimClickAction = value;
-  bool get autoStackButtons => js.autoStackButtons;
-  set autoStackButtons(bool value) => js.autoStackButtons = value;
+  String? get escapeKeyAction => js.escapeKeyAction;
+  set escapeKeyAction(String? value) => js.escapeKeyAction = value;
+  String? get scrimClickAction => js.scrimClickAction;
+  set scrimClickAction(String? value) => js.scrimClickAction = value;
+  bool? get autoStackButtons => js.autoStackButtons;
+  set autoStackButtons(bool? value) => js.autoStackButtons = value;
 
   /// Recalculates layout and automatically adds/removes modifier classes like
   /// --scrollable.

--- a/lib/src/dialog.dart
+++ b/lib/src/dialog.dart
@@ -14,7 +14,7 @@ class MDCDialog extends MDCComponent {
   static MDCDialog attachTo(Element root) => MDCDialog._attach(root);
   MDCDialog._attach(Element root) : _js = DialogComponent.attachTo(root);
 
-  MDCDialog(Element root, [MDCFoundation foundation, args])
+  MDCDialog(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   DialogComponent get js => _js;
@@ -34,7 +34,7 @@ class MDCDialog extends MDCComponent {
   void open() => js.open();
 
   /// [action] indicates why it was closed.
-  void close([String action]) => js.close();
+  void close([String? action]) => js.close();
 
   static const openingEvent = 'MDCDialog:opening';
   static const openedEvent = 'MDCDialog:opened';
@@ -47,7 +47,7 @@ class MDCDialog extends MDCComponent {
 }
 
 DialogComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? DialogComponent(root)
         : args == null

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -13,7 +13,7 @@ class MDCDrawer extends MDCComponent {
   static MDCDrawer attachTo(Element root) => MDCDrawer._attach(root);
   MDCDrawer._attach(Element root) : _js = DrawerComponent.attachTo(root);
 
-  MDCDrawer(Element root, [MDCFoundation foundation, args])
+  MDCDrawer(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   DrawerComponent get js => _js;
@@ -27,7 +27,7 @@ class MDCDrawer extends MDCComponent {
 }
 
 DrawerComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? DrawerComponent(root)
         : args == null

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -19,8 +19,8 @@ class MDCDrawer extends MDCComponent {
   DrawerComponent get js => _js;
   final DrawerComponent _js;
 
-  bool get open => js.open;
-  set open(bool value) => js.open = value;
+  bool? get open => js.open;
+  set open(bool? value) => js.open = value;
 
   static const openedEvent = 'MDCDrawer:opened';
   static const closedEvent = 'MDCDrawer:closed';

--- a/lib/src/floating_label.dart
+++ b/lib/src/floating_label.dart
@@ -14,7 +14,7 @@ class MDCFloatingLabel extends MDCComponent implements MDCSelectionControl {
   MDCFloatingLabel._attach(Element root)
       : _js = FloatingLabelComponent.attachTo(root);
 
-  MDCFloatingLabel(Element root, [MDCFoundation foundation, args])
+  MDCFloatingLabel(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   FloatingLabelComponent get js => _js;
@@ -29,7 +29,7 @@ class MDCFloatingLabel extends MDCComponent implements MDCSelectionControl {
 }
 
 FloatingLabelComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? FloatingLabelComponent(root)
         : args == null

--- a/lib/src/floating_label.dart
+++ b/lib/src/floating_label.dart
@@ -25,7 +25,7 @@ class MDCFloatingLabel extends MDCComponent implements MDCSelectionControl {
   num getWidth() => js.getWidth();
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 FloatingLabelComponent _preserveUndefined(

--- a/lib/src/form_field.dart
+++ b/lib/src/form_field.dart
@@ -14,7 +14,7 @@ class MDCFormField extends MDCComponent {
   static MDCFormField attachTo(Element root) => MDCFormField._attach(root);
   MDCFormField._attach(Element root) : _js = FormFieldComponent.attachTo(root);
 
-  MDCFormField(Element root, [MDCFoundation foundation, args])
+  MDCFormField(Element? root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   FormFieldComponent get js => _js;
@@ -25,7 +25,7 @@ class MDCFormField extends MDCComponent {
 }
 
 FormFieldComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element? root, MDCFoundation? foundation, args) =>
     foundation == null
         ? FormFieldComponent(root)
         : args == null

--- a/lib/src/icon_button.dart
+++ b/lib/src/icon_button.dart
@@ -16,7 +16,7 @@ class MDCIconButtonToggle extends MDCComponent {
   MDCIconButtonToggle._attach(Element root)
       : _js = IconButtonToggleComponent.attachTo(root);
 
-  MDCIconButtonToggle(Element root, [MDCFoundation foundation, args])
+  MDCIconButtonToggle(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   IconButtonToggleComponent get js => _js;
@@ -33,7 +33,7 @@ class MDCIconButtonToggle extends MDCComponent {
 }
 
 IconButtonToggleComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? IconButtonToggleComponent(root)
         : args == null

--- a/lib/src/icon_button.dart
+++ b/lib/src/icon_button.dart
@@ -23,8 +23,8 @@ class MDCIconButtonToggle extends MDCComponent {
   final IconButtonToggleComponent _js;
 
   /// Get/set the toggle state.
-  bool get on => js.on;
-  set on(bool value) => js.on = value;
+  bool? get on => js.on;
+  set on(bool? value) => js.on = value;
 
   MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
 

--- a/lib/src/line_ripple.dart
+++ b/lib/src/line_ripple.dart
@@ -13,7 +13,7 @@ class MDCLineRipple extends MDCComponent {
   MDCLineRipple._attach(Element root)
       : _js = LineRippleComponent.attachTo(root);
 
-  MDCLineRipple(Element root, [MDCFoundation foundation, args])
+  MDCLineRipple(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   LineRippleComponent get js => _js;
@@ -25,7 +25,7 @@ class MDCLineRipple extends MDCComponent {
 }
 
 LineRippleComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? LineRippleComponent(root)
         : args == null

--- a/lib/src/linear_progress.dart
+++ b/lib/src/linear_progress.dart
@@ -15,7 +15,7 @@ class MDCLinearProgress extends MDCComponent {
   MDCLinearProgress._attach(Element root)
       : _js = LinearProgressComponent.attachTo(root);
 
-  MDCLinearProgress(Element root, [MDCFoundation foundation, args])
+  MDCLinearProgress(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   LinearProgressComponent get js => _js;
@@ -36,7 +36,7 @@ class MDCLinearProgress extends MDCComponent {
 }
 
 LinearProgressComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? LinearProgressComponent(root)
         : args == null

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -13,7 +13,7 @@ class MDCList extends MDCComponent {
   static MDCList attachTo(Element root) => MDCList._attach(root);
   MDCList._attach(Element root) : _js = ListComponent.attachTo(root);
 
-  MDCList(Element root, [MDCFoundation foundation, args])
+  MDCList(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   ListComponent get js => _js;
@@ -30,7 +30,7 @@ class MDCList extends MDCComponent {
 }
 
 ListComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? ListComponent(root)
         : args == null

--- a/lib/src/mdc_web/auto_init.dart
+++ b/lib/src/mdc_web/auto_init.dart
@@ -12,4 +12,4 @@ import 'package:js/js.dart';
 /// * [Component Reference](https://material.io/develop/web/components/auto-init)
 /// * [Source Code](https://github.com/material-components/material-components-web/tree/master/packages/mdc-auto-init)
 @JS()
-external void autoInit([Node root, void Function(String) warn]);
+external void autoInit([Node? root, void Function(String)? warn]);

--- a/lib/src/mdc_web/base.dart
+++ b/lib/src/mdc_web/base.dart
@@ -13,7 +13,7 @@ import 'package:js/js.dart';
 @JS('MDCComponent')
 abstract class Component {
   external static Component attachTo(Element root);
-  external factory Component(Element root, [MDCFoundation foundation, args]);
+  external factory Component(Element root, [MDCFoundation? foundation, args]);
 
   external Element get root_;
   external MDCFoundation get foundation_;

--- a/lib/src/mdc_web/checkbox.dart
+++ b/lib/src/mdc_web/checkbox.dart
@@ -18,8 +18,8 @@ import 'selection_control.dart';
 abstract class CheckboxComponent extends Component
     implements SelectionControlComponent {
   external static CheckboxComponent attachTo(Element root);
-  external factory CheckboxComponent(Element root,
-      [MDCFoundation foundation, args]);
+  external factory CheckboxComponent(Element? root,
+      [MDCFoundation? foundation, args]);
 
   bool checked;
   bool indeterminate;

--- a/lib/src/mdc_web/checkbox.dart
+++ b/lib/src/mdc_web/checkbox.dart
@@ -21,8 +21,8 @@ abstract class CheckboxComponent extends Component
   external factory CheckboxComponent(Element? root,
       [MDCFoundation? foundation, args]);
 
-  bool checked;
-  bool indeterminate;
-  bool disabled;
-  String value;
+  bool? checked;
+  bool? indeterminate;
+  bool? disabled;
+  String? value;
 }

--- a/lib/src/mdc_web/chips.dart
+++ b/lib/src/mdc_web/chips.dart
@@ -18,7 +18,7 @@ import 'ripple.dart';
 abstract class ChipSetComponent extends Component {
   external static ChipSetComponent attachTo(Element root);
   external factory ChipSetComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external List get chips;
 
@@ -39,7 +39,7 @@ abstract class ChipSetComponent extends Component {
 abstract class ChipComponent extends Component {
   external static ChipComponent attachTo(Element root);
   external factory ChipComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   /// This will be the same as the id attribute on the root element. If an id is
   /// not provided, a unique one will be generated.

--- a/lib/src/mdc_web/chips.dart
+++ b/lib/src/mdc_web/chips.dart
@@ -44,8 +44,8 @@ abstract class ChipComponent extends Component {
   /// This will be the same as the id attribute on the root element. If an id is
   /// not provided, a unique one will be generated.
   external String get id;
-  bool selected;
-  bool shouldRemoveOnTrailingIconClick;
+  bool? selected;
+  bool? shouldRemoveOnTrailingIconClick;
   external RippleComponent get ripple;
 
   /// If [shouldRemoveOnTrailingIconClick] is set to false, you must manually

--- a/lib/src/mdc_web/dialog.dart
+++ b/lib/src/mdc_web/dialog.dart
@@ -21,9 +21,9 @@ abstract class DialogComponent extends Component {
       [MDCFoundation? foundation, args]);
 
   external bool get isOpen;
-  String escapeKeyAction;
-  String scrimClickAction;
-  bool autoStackButtons;
+  String? escapeKeyAction;
+  String? scrimClickAction;
+  bool? autoStackButtons;
 
   /// Recalculates layout and automatically adds/removes modifier classes like
   /// --scrollable.

--- a/lib/src/mdc_web/dialog.dart
+++ b/lib/src/mdc_web/dialog.dart
@@ -18,7 +18,7 @@ import 'base.dart';
 abstract class DialogComponent extends Component {
   external static DialogComponent attachTo(Element root);
   external factory DialogComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external bool get isOpen;
   String escapeKeyAction;
@@ -31,5 +31,5 @@ abstract class DialogComponent extends Component {
   external void open();
 
   /// [action] indicates why it was closed.
-  external void close([String action]);
+  external void close([String? action]);
 }

--- a/lib/src/mdc_web/drawer.dart
+++ b/lib/src/mdc_web/drawer.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class DrawerComponent extends Component {
   external static DrawerComponent attachTo(Element root);
   external factory DrawerComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   bool open;
 }

--- a/lib/src/mdc_web/drawer.dart
+++ b/lib/src/mdc_web/drawer.dart
@@ -19,5 +19,5 @@ abstract class DrawerComponent extends Component {
   external factory DrawerComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  bool open;
+  bool? open;
 }

--- a/lib/src/mdc_web/floating_label.dart
+++ b/lib/src/mdc_web/floating_label.dart
@@ -17,7 +17,7 @@ abstract class FloatingLabelComponent extends Component
     implements SelectionControlComponent {
   external static FloatingLabelComponent attachTo(Element root);
   external factory FloatingLabelComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external void shake(bool shouldShake);
   external void float(bool shouldFloat);

--- a/lib/src/mdc_web/form_field.dart
+++ b/lib/src/mdc_web/form_field.dart
@@ -16,8 +16,8 @@ import 'base.dart';
 @JS('MDCFormField')
 abstract class FormFieldComponent extends Component {
   external static FormFieldComponent attachTo(Element root);
-  external factory FormFieldComponent(Element root,
-      [MDCFoundation foundation, args]);
+  external factory FormFieldComponent(Element? root,
+      [MDCFoundation? foundation, args]);
 
   dynamic /*SelectionControlComponent*/ input;
 }

--- a/lib/src/mdc_web/icon_button.dart
+++ b/lib/src/mdc_web/icon_button.dart
@@ -21,7 +21,7 @@ abstract class IconButtonToggleComponent extends Component {
       [MDCFoundation? foundation, args]);
 
   /// Get/set the toggle state.
-  bool on;
+  bool? on;
 
   external RippleComponent get ripple;
 }

--- a/lib/src/mdc_web/icon_button.dart
+++ b/lib/src/mdc_web/icon_button.dart
@@ -18,7 +18,7 @@ import 'ripple.dart';
 abstract class IconButtonToggleComponent extends Component {
   external static IconButtonToggleComponent attachTo(Element root);
   external factory IconButtonToggleComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   /// Get/set the toggle state.
   bool on;

--- a/lib/src/mdc_web/line_ripple.dart
+++ b/lib/src/mdc_web/line_ripple.dart
@@ -16,7 +16,7 @@ import 'base.dart';
 abstract class LineRippleComponent extends Component {
   external static LineRippleComponent attachTo(Element root);
   external factory LineRippleComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external void activate();
   external void deactivate();

--- a/lib/src/mdc_web/linear_progress.dart
+++ b/lib/src/mdc_web/linear_progress.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class LinearProgressComponent extends Component {
   external static LinearProgressComponent attachTo(Element root);
   external factory LinearProgressComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external set determinate(bool value);
 

--- a/lib/src/mdc_web/list.dart
+++ b/lib/src/mdc_web/list.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class ListComponent extends Component {
   external static ListComponent attachTo(Element root);
   external factory ListComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external set vertical(bool value);
   external set wrapFocus(bool value);

--- a/lib/src/mdc_web/menu.dart
+++ b/lib/src/mdc_web/menu.dart
@@ -18,8 +18,8 @@ import 'menu_surface.dart';
 @JS('MDCMenu')
 abstract class MenuComponent extends Component {
   external static MenuComponent attachTo(Element root);
-  external factory MenuComponent(Element root,
-      [MDCFoundation foundation, args]);
+  external factory MenuComponent(Element? root,
+      [MDCFoundation? foundation, args]);
 
   bool open;
   bool quickOpen;

--- a/lib/src/mdc_web/menu.dart
+++ b/lib/src/mdc_web/menu.dart
@@ -21,8 +21,8 @@ abstract class MenuComponent extends Component {
   external factory MenuComponent(Element? root,
       [MDCFoundation? foundation, args]);
 
-  bool open;
-  bool quickOpen;
+  bool? open;
+  bool? quickOpen;
 
   external List get items;
 

--- a/lib/src/mdc_web/menu_surface.dart
+++ b/lib/src/mdc_web/menu_surface.dart
@@ -18,8 +18,8 @@ abstract class MenuSurfaceComponent extends Component {
   external factory MenuSurfaceComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  bool open;
-  bool quickOpen;
+  bool? open;
+  bool? quickOpen;
 
   /// See [AnchorCorner] for acceptable values.
   external void setAnchorCorner(int corner);
@@ -55,8 +55,8 @@ abstract class MenuSurfaceCorner {
 @anonymous
 abstract class AnchorMargin {
   external factory AnchorMargin({num? top, num? right, num? bottom, num? left});
-  num top;
-  num right;
-  num bottom;
-  num left;
+  num? top;
+  num? right;
+  num? bottom;
+  num? left;
 }

--- a/lib/src/mdc_web/menu_surface.dart
+++ b/lib/src/mdc_web/menu_surface.dart
@@ -16,7 +16,7 @@ import 'base.dart';
 abstract class MenuSurfaceComponent extends Component {
   external static MenuSurfaceComponent attachTo(Element root);
   external factory MenuSurfaceComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   bool open;
   bool quickOpen;
@@ -54,7 +54,7 @@ abstract class MenuSurfaceCorner {
 @JS()
 @anonymous
 abstract class AnchorMargin {
-  external factory AnchorMargin({num top, num right, num bottom, num left});
+  external factory AnchorMargin({num? top, num? right, num? bottom, num? left});
   num top;
   num right;
   num bottom;

--- a/lib/src/mdc_web/notched_outline.dart
+++ b/lib/src/mdc_web/notched_outline.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class NotchedOutlineComponent extends Component {
   external static NotchedOutlineComponent attachTo(Element root);
   external factory NotchedOutlineComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external void notch(num notchWidth, bool isRtl);
   external void closeNotch();

--- a/lib/src/mdc_web/radio.dart
+++ b/lib/src/mdc_web/radio.dart
@@ -19,7 +19,7 @@ abstract class RadioComponent extends Component
     implements SelectionControlComponent {
   external static RadioComponent attachTo(Element root);
   external factory RadioComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   bool checked;
   bool disabled;

--- a/lib/src/mdc_web/radio.dart
+++ b/lib/src/mdc_web/radio.dart
@@ -21,7 +21,7 @@ abstract class RadioComponent extends Component
   external factory RadioComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  bool checked;
-  bool disabled;
-  String value;
+  bool? checked;
+  bool? disabled;
+  String? value;
 }

--- a/lib/src/mdc_web/ripple.dart
+++ b/lib/src/mdc_web/ripple.dart
@@ -15,9 +15,9 @@ import 'base.dart';
 /// * [Source Code](https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple/index.js)
 @JS('MDCRipple')
 abstract class RippleComponent extends Component {
-  external static RippleComponent attachTo(Element root, [bool unbounded]);
+  external static RippleComponent attachTo(Element root, [bool? unbounded]);
   external factory RippleComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   /// Surfaces for bounded ripples should have the overflow property set to
   /// hidden, while surfaces for unbounded ripples should have it set to visible.

--- a/lib/src/mdc_web/ripple.dart
+++ b/lib/src/mdc_web/ripple.dart
@@ -21,8 +21,8 @@ abstract class RippleComponent extends Component {
 
   /// Surfaces for bounded ripples should have the overflow property set to
   /// hidden, while surfaces for unbounded ripples should have it set to visible.
-  bool unbounded;
-  bool disabled;
+  bool? unbounded;
+  bool? disabled;
 
   external void activate();
   external void deactivate();

--- a/lib/src/mdc_web/select.dart
+++ b/lib/src/mdc_web/select.dart
@@ -21,9 +21,9 @@ abstract class SelectComponent extends Component
   external factory SelectComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  bool disabled;
-  String value;
+  bool? disabled;
+  String? value;
 
   /// Set to -1 if no option is currently selected.
-  int selectedIndex;
+  int? selectedIndex;
 }

--- a/lib/src/mdc_web/select.dart
+++ b/lib/src/mdc_web/select.dart
@@ -19,7 +19,7 @@ abstract class SelectComponent extends Component
     implements SelectionControlComponent {
   external static SelectComponent attachTo(Element root);
   external factory SelectComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   bool disabled;
   String value;

--- a/lib/src/mdc_web/selection_control.dart
+++ b/lib/src/mdc_web/selection_control.dart
@@ -13,5 +13,5 @@ export 'ripple.dart';
 /// * [Source Code](https://github.com/material-components/material-components-web/blob/master/packages/mdc-selection-control/index.js)
 @JS('MDCSelectionControl')
 abstract class SelectionControlComponent {
-  external RippleComponent get ripple;
+  external RippleComponent? get ripple;
 }

--- a/lib/src/mdc_web/slider.dart
+++ b/lib/src/mdc_web/slider.dart
@@ -22,7 +22,7 @@ abstract class SliderComponent extends Component
     implements SelectionControlComponent {
   external static SliderComponent attachTo(Element root);
   external factory SliderComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   num value;
   num min;

--- a/lib/src/mdc_web/slider.dart
+++ b/lib/src/mdc_web/slider.dart
@@ -24,11 +24,11 @@ abstract class SliderComponent extends Component
   external factory SliderComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  num value;
-  num min;
-  num max;
-  num step;
-  bool disabled;
+  num? value;
+  num? min;
+  num? max;
+  num? step;
+  bool? disabled;
 
   external void layout();
   external void stepUp([num amount = 1]);

--- a/lib/src/mdc_web/snackbar.dart
+++ b/lib/src/mdc_web/snackbar.dart
@@ -18,12 +18,12 @@ import 'base.dart';
 abstract class SnackbarComponent extends Component {
   external static SnackbarComponent attachTo(Element root);
   external factory SnackbarComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   bool dismissesOnAction;
 
   external void open();
-  external void close([String reason]);
+  external void close([String? reason]);
   int timeoutMs;
   String labelText;
   String actionButtonText;

--- a/lib/src/mdc_web/snackbar.dart
+++ b/lib/src/mdc_web/snackbar.dart
@@ -20,12 +20,12 @@ abstract class SnackbarComponent extends Component {
   external factory SnackbarComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  bool dismissesOnAction;
+  bool? dismissesOnAction;
 
   external void open();
   external void close([String? reason]);
-  int timeoutMs;
-  String labelText;
-  String actionButtonText;
+  int? timeoutMs;
+  String? labelText;
+  String? actionButtonText;
   external bool get isOpen;
 }

--- a/lib/src/mdc_web/switch.dart
+++ b/lib/src/mdc_web/switch.dart
@@ -18,8 +18,8 @@ import 'selection_control.dart';
 abstract class SwitchComponent extends Component
     implements SelectionControlComponent {
   external static SwitchComponent attachTo(Element root);
-  external factory SwitchComponent(Element root,
-      [MDCFoundation foundation, args]);
+  external factory SwitchComponent(Element? root,
+      [MDCFoundation? foundation, args]);
 
   bool checked;
   bool disabled;

--- a/lib/src/mdc_web/switch.dart
+++ b/lib/src/mdc_web/switch.dart
@@ -21,6 +21,6 @@ abstract class SwitchComponent extends Component
   external factory SwitchComponent(Element? root,
       [MDCFoundation? foundation, args]);
 
-  bool checked;
-  bool disabled;
+  bool? checked;
+  bool? disabled;
 }

--- a/lib/src/mdc_web/tab.dart
+++ b/lib/src/mdc_web/tab.dart
@@ -16,7 +16,7 @@ import 'base.dart';
 @JS('MDCTab')
 abstract class TabComponent extends Component {
   external static TabComponent attachTo(Element root);
-  external factory TabComponent(Element root, [MDCFoundation foundation, args]);
+  external factory TabComponent(Element root, [MDCFoundation? foundation, args]);
 
   external bool get active;
 
@@ -36,7 +36,7 @@ abstract class TabComponent extends Component {
 @anonymous
 abstract class MDCTabDimensions {
   external factory MDCTabDimensions(
-      {num rootLeft, num rootRight, num contentLeft, num contentRight});
+      {num? rootLeft, num? rootRight, num? contentLeft, num? contentRight});
   num rootLeft;
   num rootRight;
   num contentLeft;

--- a/lib/src/mdc_web/tab.dart
+++ b/lib/src/mdc_web/tab.dart
@@ -37,8 +37,8 @@ abstract class TabComponent extends Component {
 abstract class MDCTabDimensions {
   external factory MDCTabDimensions(
       {num? rootLeft, num? rootRight, num? contentLeft, num? contentRight});
-  num rootLeft;
-  num rootRight;
-  num contentLeft;
-  num contentRight;
+  num? rootLeft;
+  num? rootRight;
+  num? contentLeft;
+  num? contentRight;
 }

--- a/lib/src/mdc_web/tab_bar.dart
+++ b/lib/src/mdc_web/tab_bar.dart
@@ -19,7 +19,7 @@ import 'base.dart';
 abstract class TabBarComponent extends Component {
   external static TabBarComponent attachTo(Element root);
   external factory TabBarComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external void activateTab(int index);
   external void scrollIntoView(int index);

--- a/lib/src/mdc_web/tab_indicator.dart
+++ b/lib/src/mdc_web/tab_indicator.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class TabIndicatorComponent extends Component {
   external static TabIndicatorComponent attachTo(Element root);
   external factory TabIndicatorComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   /// [previousIndicatorClientRect] is a DOMRect. See also
   /// [computeIndicatorClientRect()].

--- a/lib/src/mdc_web/tab_scroller.dart
+++ b/lib/src/mdc_web/tab_scroller.dart
@@ -17,7 +17,7 @@ import 'base.dart';
 abstract class TabScrollerComponent extends Component {
   external static TabScrollerComponent attachTo(Element root);
   external factory TabScrollerComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   external void scrollTo(num scrollX);
   external void incrementScroll(num scrollX);

--- a/lib/src/mdc_web/text_field.dart
+++ b/lib/src/mdc_web/text_field.dart
@@ -19,7 +19,7 @@ abstract class TextFieldComponent extends Component
     implements SelectionControlComponent {
   external static TextFieldComponent attachTo(Element root);
   external factory TextFieldComponent(Element root,
-      [MDCFoundation foundation, args]);
+      [MDCFoundation? foundation, args]);
 
   String value;
   bool disabled;

--- a/lib/src/mdc_web/text_field.dart
+++ b/lib/src/mdc_web/text_field.dart
@@ -21,17 +21,17 @@ abstract class TextFieldComponent extends Component
   external factory TextFieldComponent(Element root,
       [MDCFoundation? foundation, args]);
 
-  String value;
-  bool disabled;
-  bool valid;
-  RippleComponent ripple;
-  bool required;
-  int minLength;
-  int maxLength;
-  String min;
-  String max;
-  String step;
-  String pattern;
+  String? value;
+  bool? disabled;
+  bool? valid;
+  RippleComponent? ripple;
+  bool? required;
+  int? minLength;
+  int? maxLength;
+  String? min;
+  String? max;
+  String? step;
+  String? pattern;
 
   external set useNativeValidation(bool value);
   external set helperTextContent(String value);

--- a/lib/src/mdc_web/top_app_bar.dart
+++ b/lib/src/mdc_web/top_app_bar.dart
@@ -17,8 +17,8 @@ import 'base.dart';
 @JS('MDCTopAppBar')
 abstract class TopAppBarComponent extends Component {
   external static TopAppBarComponent attachTo(Element root);
-  external factory TopAppBarComponent(Element root,
-      [MDCFoundation foundation, args]);
+  external factory TopAppBarComponent(Element? root,
+      [MDCFoundation? foundation, args]);
 
   /// The default scroll target is `window`.
   external void setScrollTarget(Element target);

--- a/lib/src/menu.dart
+++ b/lib/src/menu.dart
@@ -23,10 +23,10 @@ class MDCMenu extends MDCComponent {
   MenuComponent get js => _js;
   final MenuComponent _js;
 
-  bool get open => js.open;
-  set open(bool value) => js.open = value;
-  bool get quickOpen => js.quickOpen;
-  set quickOpen(bool value) => js.quickOpen = value;
+  bool? get open => js.open;
+  set open(bool? value) => js.open = value;
+  bool? get quickOpen => js.quickOpen;
+  set quickOpen(bool? value) => js.quickOpen = value;
 
   List<Element> get items => List.from(js.items);
 

--- a/lib/src/menu.dart
+++ b/lib/src/menu.dart
@@ -17,7 +17,7 @@ class MDCMenu extends MDCComponent {
   static MDCMenu attachTo(Element root) => MDCMenu._attach(root);
   MDCMenu._attach(Element root) : _js = MenuComponent.attachTo(root);
 
-  MDCMenu(Element root, [MDCFoundation foundation, args])
+  MDCMenu(Element? root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   MenuComponent get js => _js;
@@ -50,7 +50,7 @@ class MDCMenu extends MDCComponent {
 }
 
 MenuComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element? root, MDCFoundation? foundation, args) =>
     foundation == null
         ? MenuComponent(root)
         : args == null

--- a/lib/src/menu_surface.dart
+++ b/lib/src/menu_surface.dart
@@ -21,10 +21,10 @@ class MDCMenuSurface extends MDCComponent {
   MenuSurfaceComponent get js => _js;
   final MenuSurfaceComponent _js;
 
-  bool get open => js.open;
-  set open(bool value) => js.open = value;
-  bool get quickOpen => js.quickOpen;
-  set quickOpen(bool value) => js.quickOpen = value;
+  bool? get open => js.open;
+  set open(bool? value) => js.open = value;
+  bool? get quickOpen => js.quickOpen;
+  set quickOpen(bool? value) => js.quickOpen = value;
 
   /// See [AnchorCorner] for acceptable values.
   void setAnchorCorner(int corner) => js.setAnchorCorner(corner);

--- a/lib/src/menu_surface.dart
+++ b/lib/src/menu_surface.dart
@@ -15,7 +15,7 @@ class MDCMenuSurface extends MDCComponent {
   MDCMenuSurface._attach(Element root)
       : _js = MenuSurfaceComponent.attachTo(root);
 
-  MDCMenuSurface(Element root, [MDCFoundation foundation, args])
+  MDCMenuSurface(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   MenuSurfaceComponent get js => _js;
@@ -48,7 +48,7 @@ class MDCMenuSurface extends MDCComponent {
 }
 
 MenuSurfaceComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? MenuSurfaceComponent(root)
         : args == null

--- a/lib/src/notched_outline.dart
+++ b/lib/src/notched_outline.dart
@@ -15,7 +15,7 @@ class MDCNotchedOutline extends MDCComponent {
   MDCNotchedOutline._attach(Element root)
       : _js = NotchedOutlineComponent.attachTo(root);
 
-  MDCNotchedOutline(Element root, [MDCFoundation foundation, args])
+  MDCNotchedOutline(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   NotchedOutlineComponent get js => _js;
@@ -26,7 +26,7 @@ class MDCNotchedOutline extends MDCComponent {
 }
 
 NotchedOutlineComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? NotchedOutlineComponent(root)
         : args == null

--- a/lib/src/radio.dart
+++ b/lib/src/radio.dart
@@ -14,7 +14,7 @@ class MDCRadio extends MDCComponent implements MDCSelectionControl {
   static MDCRadio attachTo(Element root) => MDCRadio._attach(root);
   MDCRadio._attach(Element root) : _js = RadioComponent.attachTo(root);
 
-  MDCRadio(Element root, [MDCFoundation foundation, args])
+  MDCRadio(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   RadioComponent get js => _js;
@@ -32,7 +32,7 @@ class MDCRadio extends MDCComponent implements MDCSelectionControl {
 }
 
 RadioComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? RadioComponent(root)
         : args == null

--- a/lib/src/radio.dart
+++ b/lib/src/radio.dart
@@ -20,15 +20,15 @@ class MDCRadio extends MDCComponent implements MDCSelectionControl {
   RadioComponent get js => _js;
   final RadioComponent _js;
 
-  bool get checked => js.checked;
-  set checked(bool value) => js.checked = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
-  String get value => js.value;
-  set value(String value) => js.value = value;
+  bool? get checked => js.checked;
+  set checked(bool? value) => js.checked = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
+  String? get value => js.value;
+  set value(String? value) => js.value = value;
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 RadioComponent _preserveUndefined(

--- a/lib/src/ripple.dart
+++ b/lib/src/ripple.dart
@@ -10,11 +10,11 @@ import 'mdc_web/ripple.dart';
 /// * [Demo](https://material-components.github.io/material-components-web-catalog/#/component/ripple)
 /// * [Source Code](https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple/index.js)
 class MDCRipple extends MDCComponent {
-  static MDCRipple attachTo(Element root, [bool unbounded]) =>
+  static MDCRipple attachTo(Element root, [bool? unbounded]) =>
       MDCRipple._attach(root, unbounded);
-  MDCRipple._attach(Element root, [bool unbounded])
+  MDCRipple._attach(Element root, [bool? unbounded])
       : _js = _preserveUndefinedAttach(root, unbounded);
-  MDCRipple(Element root, [MDCFoundation foundation, args])
+  MDCRipple(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   MDCRipple.fromComponent(this._js);
@@ -38,13 +38,13 @@ class MDCRipple extends MDCComponent {
 }
 
 RippleComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? RippleComponent(root)
         : args == null
             ? RippleComponent(root, foundation)
             : RippleComponent(root, foundation, args);
-RippleComponent _preserveUndefinedAttach(Element root, bool unbounded) =>
+RippleComponent _preserveUndefinedAttach(Element root, bool? unbounded) =>
     unbounded == null
         ? RippleComponent.attachTo(root)
         : RippleComponent.attachTo(root, unbounded);

--- a/lib/src/ripple.dart
+++ b/lib/src/ripple.dart
@@ -24,10 +24,10 @@ class MDCRipple extends MDCComponent {
 
   /// Surfaces for bounded ripples should have the overflow property set to
   /// hidden, while surfaces for unbounded ripples should have it set to visible.
-  bool get unbounded => js.unbounded;
-  set unbounded(bool value) => js.unbounded = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
+  bool? get unbounded => js.unbounded;
+  set unbounded(bool? value) => js.unbounded = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
 
   void activate() => js.activate();
   void deactivate() => js.deactivate();

--- a/lib/src/select.dart
+++ b/lib/src/select.dart
@@ -14,7 +14,7 @@ class MDCSelect extends MDCComponent implements MDCSelectionControl {
   static MDCSelect attachTo(Element root) => MDCSelect._attach(root);
   MDCSelect._attach(Element root) : _js = SelectComponent.attachTo(root);
 
-  MDCSelect(Element root, [MDCFoundation foundation, args])
+  MDCSelect(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   SelectComponent get js => _js;
@@ -34,7 +34,7 @@ class MDCSelect extends MDCComponent implements MDCSelectionControl {
 }
 
 SelectComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? SelectComponent(root)
         : args == null

--- a/lib/src/select.dart
+++ b/lib/src/select.dart
@@ -20,17 +20,17 @@ class MDCSelect extends MDCComponent implements MDCSelectionControl {
   SelectComponent get js => _js;
   final SelectComponent _js;
 
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
-  String get value => js.value;
-  set value(String value) => js.value = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
+  String? get value => js.value;
+  set value(String? value) => js.value = value;
 
   /// Set to -1 if no option is currently selected.
-  int get selectedIndex => js.selectedIndex;
-  set selectedIndex(int value) => js.selectedIndex = value;
+  int? get selectedIndex => js.selectedIndex;
+  set selectedIndex(int? value) => js.selectedIndex = value;
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 SelectComponent _preserveUndefined(

--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -23,23 +23,23 @@ class MDCSlider extends MDCComponent implements MDCSelectionControl {
   SliderComponent get js => _js;
   final SliderComponent _js;
 
-  num get value => js.value;
-  set value(num value) => js.value = value;
-  num get min => js.min;
-  set min(num value) => js.min = value;
-  num get max => js.max;
-  set max(num value) => js.max = value;
-  num get step => js.step;
-  set step(num value) => js.step = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
+  num? get value => js.value;
+  set value(num? value) => js.value = value;
+  num? get min => js.min;
+  set min(num? value) => js.min = value;
+  num? get max => js.max;
+  set max(num? value) => js.max = value;
+  num? get step => js.step;
+  set step(num? value) => js.step = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
 
   void layout() => js.layout();
   void stepUp([num amount = 1]) => js.stepUp(amount);
   void stepDown([num amount = 1]) => js.stepDown(amount);
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 
   /// Emitted whenever the slider value is changed by way of a user event, e.g.
   /// when a user is dragging the slider or changing the value using the arrow

--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -17,7 +17,7 @@ class MDCSlider extends MDCComponent implements MDCSelectionControl {
   static MDCSlider attachTo(Element root) => MDCSlider._attach(root);
   MDCSlider._attach(Element root) : _js = SliderComponent.attachTo(root);
 
-  MDCSlider(Element root, [MDCFoundation foundation, args])
+  MDCSlider(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   SliderComponent get js => _js;
@@ -55,7 +55,7 @@ class MDCSlider extends MDCComponent implements MDCSelectionControl {
 }
 
 SliderComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? SliderComponent(root)
         : args == null

--- a/lib/src/snackbar.dart
+++ b/lib/src/snackbar.dart
@@ -22,14 +22,14 @@ class MDCSnackbar extends MDCComponent {
 
   bool get isOpen => js.isOpen;
 
-  String get labelText => js.labelText;
-  void set labelText(String text) => js.labelText = text;
+  String? get labelText => js.labelText;
+  void set labelText(String? text) => js.labelText = text;
 
-  String get actionButtonText => js.actionButtonText;
-  void set actionButtonText(String text) => js.actionButtonText = text;
+  String? get actionButtonText => js.actionButtonText;
+  void set actionButtonText(String? text) => js.actionButtonText = text;
 
-  int get timeoutMs => js.timeoutMs;
-  void set timeoutMs(int t) => js.timeoutMs = t;
+  int? get timeoutMs => js.timeoutMs;
+  void set timeoutMs(int? t) => js.timeoutMs = t;
 
   void open() => js.open();
   void close([String? reason]) => js.close(reason);

--- a/lib/src/snackbar.dart
+++ b/lib/src/snackbar.dart
@@ -14,7 +14,7 @@ class MDCSnackbar extends MDCComponent {
   static MDCSnackbar attachTo(Element root) => MDCSnackbar._attach(root);
   MDCSnackbar._attach(Element root) : _js = SnackbarComponent.attachTo(root);
 
-  MDCSnackbar(Element root, [MDCFoundation foundation, args])
+  MDCSnackbar(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   SnackbarComponent get js => _js;
@@ -32,11 +32,11 @@ class MDCSnackbar extends MDCComponent {
   void set timeoutMs(int t) => js.timeoutMs = t;
 
   void open() => js.open();
-  void close([String reason]) => js.close(reason);
+  void close([String? reason]) => js.close(reason);
 }
 
 SnackbarComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? SnackbarComponent(root)
         : args == null

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -20,13 +20,13 @@ class MDCSwitch extends MDCComponent implements MDCSelectionControl {
   SwitchComponent get js => _js;
   final SwitchComponent _js;
 
-  bool get checked => js.checked;
-  set checked(bool value) => js.checked = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
+  bool? get checked => js.checked;
+  set checked(bool? value) => js.checked = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 SwitchComponent _preserveUndefined(

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -14,7 +14,7 @@ class MDCSwitch extends MDCComponent implements MDCSelectionControl {
   static MDCSwitch attachTo(Element root) => MDCSwitch._attach(root);
   MDCSwitch._attach(Element root) : _js = SwitchComponent.attachTo(root);
 
-  MDCSwitch(Element root, [MDCFoundation foundation, args])
+  MDCSwitch(Element? root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   SwitchComponent get js => _js;
@@ -30,7 +30,7 @@ class MDCSwitch extends MDCComponent implements MDCSelectionControl {
 }
 
 SwitchComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element? root, MDCFoundation? foundation, args) =>
     foundation == null
         ? SwitchComponent(root)
         : args == null

--- a/lib/src/tab.dart
+++ b/lib/src/tab.dart
@@ -15,7 +15,7 @@ class MDCTab extends MDCComponent {
   static MDCTab attachTo(Element root) => MDCTab._attach(root);
   MDCTab._attach(Element root) : _js = TabComponent.attachTo(root);
 
-  MDCTab(Element root, [MDCFoundation foundation, args])
+  MDCTab(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TabComponent get js => _js;
@@ -42,7 +42,7 @@ class MDCTab extends MDCComponent {
   static const interactedEvent = 'MDCTab:interacted';
 }
 
-TabComponent _preserveUndefined(Element root, MDCFoundation foundation, args) =>
+TabComponent _preserveUndefined(Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TabComponent(root)
         : args == null

--- a/lib/src/tab_bar.dart
+++ b/lib/src/tab_bar.dart
@@ -15,7 +15,7 @@ class MDCTabBar extends MDCComponent {
   static MDCTabBar attachTo(Element root) => MDCTabBar._attach(root);
   MDCTabBar._attach(Element root) : _js = TabBarComponent.attachTo(root);
 
-  MDCTabBar(Element root, [MDCFoundation foundation, args])
+  MDCTabBar(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TabBarComponent get js => _js;
@@ -29,7 +29,7 @@ class MDCTabBar extends MDCComponent {
 }
 
 TabBarComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TabBarComponent(root)
         : args == null

--- a/lib/src/tab_indicator.dart
+++ b/lib/src/tab_indicator.dart
@@ -15,7 +15,7 @@ class MDCTabIndicator extends MDCComponent {
   MDCTabIndicator._attach(Element root)
       : _js = TabIndicatorComponent.attachTo(root);
 
-  MDCTabIndicator(Element root, [MDCFoundation foundation, args])
+  MDCTabIndicator(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TabIndicatorComponent get js => _js;
@@ -32,7 +32,7 @@ class MDCTabIndicator extends MDCComponent {
 }
 
 TabIndicatorComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TabIndicatorComponent(root)
         : args == null

--- a/lib/src/tab_scroller.dart
+++ b/lib/src/tab_scroller.dart
@@ -14,7 +14,7 @@ class MDCTabScroller extends MDCComponent {
   MDCTabScroller._attach(Element root)
       : _js = TabScrollerComponent.attachTo(root);
 
-  MDCTabScroller(Element root, [MDCFoundation foundation, args])
+  MDCTabScroller(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TabScrollerComponent get js => _js;
@@ -27,7 +27,7 @@ class MDCTabScroller extends MDCComponent {
 }
 
 TabScrollerComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TabScrollerComponent(root)
         : args == null

--- a/lib/src/text_field.dart
+++ b/lib/src/text_field.dart
@@ -20,10 +20,10 @@ class MDCTextField extends MDCComponent implements MDCSelectionControl {
   TextFieldComponent get js => _js;
   final TextFieldComponent _js;
 
-  String get value => js.value;
-  set value(String value) => js.value = value;
-  bool get disabled => js.disabled;
-  set disabled(bool value) => js.disabled = value;
+  String? get value => js.value;
+  set value(String? value) => js.value = value;
+  bool? get disabled => js.disabled;
+  set disabled(bool? value) => js.disabled = value;
   set useNativeValidation(bool value) => js.useNativeValidation = value;
   set helperTextContent(String value) => js.helperTextContent = value;
   set leadingIconAriaLabel(String value) => js.leadingIconAriaLabel = value;
@@ -31,28 +31,28 @@ class MDCTextField extends MDCComponent implements MDCSelectionControl {
   set leadingIconContent(String value) => js.leadingIconContent = value;
   set trailingIconContent(String value) => js.trailingIconContent = value;
   set ripple(MDCRipple value) => js.ripple = value.js;
-  bool get valid => js.valid;
-  set valid(bool value) => js.valid = value;
+  bool? get valid => js.valid;
+  set valid(bool? value) => js.valid = value;
 
-  bool get required => js.required;
-  set required(bool value) => js.required = value;
-  int get minLength => js.minLength;
-  set minLength(int value) => js.minLength = value;
-  int get maxLength => js.maxLength;
-  set maxLength(int value) => js.maxLength = value;
-  String get min => js.min;
-  set min(String value) => js.min = value;
-  String get max => js.max;
-  set max(String value) => js.max = value;
-  String get step => js.step;
-  set step(String value) => js.step = value;
-  String get pattern => js.pattern;
-  set pattern(String value) => js.pattern = value;
+  bool? get required => js.required;
+  set required(bool? value) => js.required = value;
+  int? get minLength => js.minLength;
+  set minLength(int? value) => js.minLength = value;
+  int? get maxLength => js.maxLength;
+  set maxLength(int? value) => js.maxLength = value;
+  String? get min => js.min;
+  set min(String? value) => js.min = value;
+  String? get max => js.max;
+  set max(String? value) => js.max = value;
+  String? get step => js.step;
+  set step(String? value) => js.step = value;
+  String? get pattern => js.pattern;
+  set pattern(String? value) => js.pattern = value;
 
   void layout() => js.layout();
 
   @override
-  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple);
+  MDCRipple get ripple => MDCRipple.fromComponent(js.ripple!);
 }
 
 TextFieldComponent _preserveUndefined(

--- a/lib/src/text_field.dart
+++ b/lib/src/text_field.dart
@@ -14,7 +14,7 @@ class MDCTextField extends MDCComponent implements MDCSelectionControl {
   static MDCTextField attachTo(Element root) => MDCTextField._attach(root);
   MDCTextField._attach(Element root) : _js = TextFieldComponent.attachTo(root);
 
-  MDCTextField(Element root, [MDCFoundation foundation, args])
+  MDCTextField(Element root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TextFieldComponent get js => _js;
@@ -56,7 +56,7 @@ class MDCTextField extends MDCComponent implements MDCSelectionControl {
 }
 
 TextFieldComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TextFieldComponent(root)
         : args == null

--- a/lib/src/top_app_bar.dart
+++ b/lib/src/top_app_bar.dart
@@ -14,7 +14,7 @@ class MDCTopAppBar extends MDCComponent {
   static MDCTopAppBar attachTo(Element root) => MDCTopAppBar._attach(root);
   MDCTopAppBar._attach(Element root) : _js = TopAppBarComponent.attachTo(root);
 
-  MDCTopAppBar(Element root, [MDCFoundation foundation, args])
+  MDCTopAppBar(Element? root, [MDCFoundation? foundation, args])
       : _js = _preserveUndefined(root, foundation, args);
 
   TopAppBarComponent get js => _js;
@@ -28,7 +28,7 @@ class MDCTopAppBar extends MDCComponent {
 }
 
 TopAppBarComponent _preserveUndefined(
-        Element root, MDCFoundation foundation, args) =>
+        Element? root, MDCFoundation? foundation, args) =>
     foundation == null
         ? TopAppBarComponent(root)
         : args == null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Jacob Phillips <jifalops@gmail.com>
 homepage: https://github.com/jifalops/mdc_web
 
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   js: ^0.6.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mdc_web
 description: Dart wrapper for the material-components-web javascript library.
-version: 0.5.0-pre
+version: 0.6.0
 author: Jacob Phillips <jifalops@gmail.com>
 homepage: https://github.com/jifalops/mdc_web
 


### PR DESCRIPTION
This runs the `dart migrate` command with some tweaks for JS interop. I made most of the types nullable, but if there are any places where they should be non-nullable, I'm happy to make a change.
